### PR TITLE
Add profiling source information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ lto = "thin"
 [profile.profile]
 inherits="release"
 strip = false
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ strip = true
 codegen-units = 1
 lto = "thin"
 
-[profile.profile]
+[profile.profiling]
 inherits="release"
 strip = false
 debug = true


### PR DESCRIPTION
With the added debug info we can correlate profiling info with source locations. This makes it possible to e.g., see line costs, e.g., this PR on top of #7 (takeaway: most time spent in reading the input anyway and no reason to obsess about optimizing the code here):

<img width="1024" alt="Screenshot 2023-11-11 at 11 47 11 AM" src="https://github.com/open-dms/osmtools/assets/324957/ec7c317c-6fae-46ab-ba8f-7e026f0c8735">
